### PR TITLE
Print out timestamp on each cycle

### DIFF
--- a/vmguest-stats
+++ b/vmguest-stats
@@ -60,6 +60,8 @@ while count == -1 or count > 0:
 
     gl.UpdateInfo()
 
+    print time.asctime()
+
     # TODO: Add clearscreen and bold/underline escape sequences
     if options.cpu:
         NewElapsedMs = gl.GetElapsedMs()


### PR DESCRIPTION
This makes it easier to correlate with other sources of log data, e.g. you can cross reference %CPU steal with slow HTTP responses, or bursts of load, etc.