### PR TITLE
Corrected method name for Host CPU Used MS

### DIFF
--- a/vmguestlib.py
+++ b/vmguestlib.py
@@ -221,7 +221,7 @@ class VMGuestLib(Structure):
     def GetHostCpuUsedMs(self):
         '''Undocumented.'''
         counter = c_uint64()
-        ret = vmGuestLib.VMGuestLib_GetHostMemSwappedMB(self.handle.value, byref(counter))
+        ret = vmGuestLib.VMGuestLib_GetHostCpuUsedMs(self.handle.value, byref(counter))
         if ret != VMGUESTLIB_ERROR_SUCCESS: raise VMGuestLibException(ret)
         return counter.value
 


### PR DESCRIPTION
Corrected method name for Host CPU Used MS from
VMGuestLib_GetHostMemSwappedMB to VMGuestLib_GetHostCpuUsedMs